### PR TITLE
Applied general layout styling to search listings

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -14,7 +14,7 @@ body, html {
     width: 100%;
     height: 10%;
     /* Temporary background color to see layout */
-    background-color: beige;
+    background-color: #99e0ec;
 }
    
 .logo {
@@ -31,7 +31,7 @@ body, html {
     height: 90%;
 
     /* Temporary background color to see layout */
-    background-color: rgb(167, 184, 233);
+    background-color: #99e0ec;
 }
 
 .map {
@@ -54,18 +54,33 @@ body, html {
     width: 90%;
     height: 5rem;
     margin: auto;
-    border: .1em solid black;
+    margin-bottom: 0.2em;
+    border: .1em solid gray;
+    font-size: 1.5em;
+    border-radius: 0.2em;
 
     /* Temporary background color to see layout */
     background-color: white;
 }
 
+.listing:hover {
+    /* Temporary colors. Okay to modify */
+    background-color: lightyellow;
+    border: 0.2em solid green;
+}
+
 .listing-image {
     width: 6rem;
     height: 5rem;
+}
 
-    /* Temporary background color to see layout */
-    background-color: blue;
+.listing-info {
+    margin-left: 0.5em;
+}
+
+.listing-title {
+    margin-top: 0.4em;
+    font-weight: bold;
 }
 
 .info-window-title {
@@ -93,6 +108,23 @@ body, html {
         object-fit: cover; 
     }
 
+    .search-listings {
+        height: 85%;
+        padding-top: 0.5em;
+    }
+
+    .listing {
+        width: 95%;
+        height: 8rem;
+        margin-left: 0.7em;
+        padding-right: 0.7em;
+    }
+
+    .listing-image {
+        width: 8rem;
+        height: 8rem;
+    }
+
     .description-visibility {
         visibility: visible;
     }
@@ -101,5 +133,15 @@ body, html {
 @media(min-width: 1200px) {
     .main {
         flex-direction: row;
+    }
+
+    .listing {
+        width: 100%;
+        height: 10rem;
+    }
+
+    .listing-image {
+        width: 10rem;
+        height: 10rem;
     }
 }


### PR DESCRIPTION
In this branch: 

- Styled elements within search listings for mobile and media queries at 768px and 1200px (see: stylesheets/styles.css). 

Note: Styling is very general and applies more to the layout of the search listings. It is okay to modify in future revisions. 

@williammadisondavis and @clinturbin: Could you please take a look and help review? 🙂