### PR TITLE
Styled search box

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     </div>
     </div>
     <div class="main">
-        <input class="search-input" type="text" placeholder="Search Box">
+        <input class="search-input" type="text" placeholder="Search">
         <div class="map">
             <!-- Map generated in JS -->
         </div>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -24,6 +24,15 @@ body, html {
     object-fit: cover;
 }
 
+.search-input {
+    outline: none;
+    margin-top: 0.8em;
+    height: 2em;
+    width: 11em;
+    font-size: 1.3rem;
+    box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
+}
+
 .main {
     display: flex;
     flex-direction: column;
@@ -102,6 +111,10 @@ body, html {
         height: 100%;
         width: 65rem;
         object-fit: cover; 
+    }
+
+    .search-input {
+        width: 23em;
     }
 
     .map {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -30,7 +30,7 @@ body, html {
     height: 2em;
     width: 11em;
     font-size: 1.3rem;
-    box-shadow: rgba(0, 0, 0, 0.3) 0px 1px 4px -1px;
+    box-shadow: rgba(0, 0, 0, 0.3) 0em 0.1em 0.4em -0.1em;
 }
 
 .main {


### PR DESCRIPTION
Changes in this branch: 

- Renamed search box's placeholder attribute from 'Search box' to 'Search' (see index.html)
- Styled the search box for mobile and media query at 768px (see styles.css)

Most notable style changes:

- Removing the automatic blue outline that occurs when the user clicks on the box
- Adding in a box shadow to match the other map buttons 

@williammadisondavis or @clinturbin: Could either one of you please help review? 🙂