### PR TITLE
Updated search listing height & margins to correspond with map

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -7,8 +7,6 @@ body, html {
     font-size: 10px;
     background-image: url('../assets/splash.png');
     background-size: cover;
-
-
 }
 
 .header {
@@ -39,7 +37,7 @@ body, html {
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 90%;
+    height: 100%;
 }
 
 .map {
@@ -50,7 +48,7 @@ body, html {
     width: 100%;
     height: 30%;
     overflow-y: auto;
-    margin-top: 0.5em;
+    margin-top: 1em;
 }
 
 .listing {
@@ -128,7 +126,6 @@ body, html {
 
 
 @media(min-width: 768px) {
-
     .search-input {
         width: 23em;
     }
@@ -140,8 +137,8 @@ body, html {
     }
 
     .search-listings {
-        height: 85%;
-        padding-top: 0.5em;
+        height: 90%;
+        margin-top: 1.5em;
     }
 
     .listing {
@@ -173,7 +170,7 @@ body, html {
     }
 
     .map {
-        margin-top: 1em;
+        margin: 1% 1% 1% 2%;
         width: 50%;
         height: 90%;
         border-radius: .5rem;
@@ -186,6 +183,7 @@ body, html {
 
     .search-listings {
         width: 50%;
+        margin: 1% 1.5% 1% 1%;
     }
 
     .listing-image {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -42,10 +42,11 @@ body, html {
 
 .map {
     height: 70%;
+    border-radius: 0.5em;
+    border: 0.3em solid lightgrey;
 }
 
 .search-listings {
-    width: 100%;
     height: 30%;
     overflow-y: auto;
     margin-top: 1em;
@@ -131,14 +132,13 @@ body, html {
     }
 
     .map {
+        margin: 0 4%; 
         height: 75%;
-        border-radius: 0.5em;
-        border: 0.3em solid lightgrey;
     }
 
     .search-listings {
+        margin: 2.5%;
         height: 90%;
-        margin-top: 1.5em;
     }
 
     .listing {
@@ -173,7 +173,6 @@ body, html {
         margin: 1% 1% 1% 2%;
         width: 50%;
         height: 90%;
-        border-radius: .5rem;
     }
 
     .listing {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -37,7 +37,7 @@ body, html {
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 100%;
+    height: 90%;
 }
 
 .map {


### PR DESCRIPTION
In this branch: 

- Updated search listings' height to match with the map's. This is done at media query 1200px. Both are now set at height: 90%
- Updated margins on both map and search listings

@clinturbin: Could you please help review? 🙂