### PR TITLE
Replace Google Maps' API Key with variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
             </div>
         </div>
     </div>
+    <script src="scripts/config.js"></script>
     <script src="scripts/data.js"></script>
     <script src="scripts/main.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCeqLMaGy-y8ab1N-GA5zCNL7NGmwRmUzU&callback=initMap&libraries=places"
-    async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?&callback=initMap&libraries=places&key=" + gmKey async defer></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,6 @@
 var pins = pinsData.PINS;
 
+var gmKey = config.GM_KEY;
 var map;
 var mapContainer = document.querySelector(".map");
 var searchListings = document.querySelector(".search-listings");


### PR DESCRIPTION
**Important note:** We invalidated our old Google Maps API Key after accidentally committing it onto Github. The API keys previously referenced and shared throughout this repository will not work anymore. This branch uses a new API key. 

Changes in this branch:

In index.html:
- Added a new script tag referencing the location of our new Google Maps API Key. 
- In the Google Maps API script, replaced the whole API Key value with a variable, 'gmKey'.

In main.js:
- Declared the variable (var gmKey) and set it equal to the config object (in scripts/config.js) where the real Google Maps API Key is stored.

In config.js (hidden publicly, but on the local machine):
- Declared config variable object storing the Google Maps API Key.

```
var config = {
  GM_KEY: "your-key-here"
};
```

In .gitignore (previously added into the master branch):
- Placed scripts/config.js into the file, so that our real API key, which is stored in there, is not shared publicly on Github.

@clinturbin: Could you please help review? 🙂